### PR TITLE
Avoid double-running filter smoke actions

### DIFF
--- a/libs/excel_params.py
+++ b/libs/excel_params.py
@@ -1584,21 +1584,9 @@ def check_report_filters(
         ftype = _resolve_filter_type()
         _log(f"[COLUMN] {anchor} — filter type: {ftype}")
 
-        # общий smoke для UI
-        _smoke_filter_ui(anchor, ftype, row_index=row_index)
-
-        # ДЛЯ каждого типа – минимальный интеракшн (см. вспомогательные функции)
+        # общий smoke для UI + минимальный интеракшн (внутри _smoke_filter_ui)
         try:
-            if ftype == "text":
-                _run_text_filter_smoke(anchor, row_index=row_index)
-            elif ftype == "numeric":
-                _run_numeric_filter_smoke(anchor, row_index=row_index)
-            elif ftype == "datetime":
-                _run_datetime_filter_smoke(anchor, row_index=row_index)
-            elif ftype == "multiselect":
-                _run_multiselect_filter_smoke(anchor, row_index=row_index)
-            else:
-                _log(f"[COLUMN] {anchor} — unknown filter type '{ftype}'", level="WARN")
+            _smoke_filter_ui(anchor, ftype, row_index=row_index)
         except Exception as e:
             _log(f"[COLUMN] {anchor} — filter smoke failed: {type(e).__name__}: {e}", level="WARN")
 


### PR DESCRIPTION
## Summary
- stop invoking the filter smoke helpers twice for each column
- wrap the `_smoke_filter_ui` call so failures are still logged without aborting the sweep
- this prevents a second click on the same numeric filter that previously timed out

## Testing
- not run (logic change only)


------
https://chatgpt.com/codex/tasks/task_e_68d50b2af21083238615b91f7630d7ea