### PR TITLE
Fix multiselect filter detection order

### DIFF
--- a/libs/excel_params.py
+++ b/libs/excel_params.py
@@ -2376,10 +2376,10 @@ def _detect_filter_type():
             texts = [i.get_attribute("value") or "" for i in dd.find_elements(By.CSS_SELECTOR, ".ant-picker .ant-picker-input input")]
             has_time = any(":" in t for t in texts)
             return "datetime" if has_time else "date"
-        if dd.find_elements(By.CSS_SELECTOR, "input[inputmode='numeric'], input[type='number']"):
-            return "numeric"
         if dd.find_elements(By.CSS_SELECTOR, ".ant-checkbox-wrapper, .ant-dropdown-menu-item, .ant-select-item-option"):
             return "checkbox-list"
+        if dd.find_elements(By.CSS_SELECTOR, "input[inputmode='numeric'], input[type='number']"):
+            return "numeric"
         if dd.find_elements(By.XPATH, ".//input[not(@type='hidden') and not(@readonly) and not(ancestor::*[contains(@class,'ant-select')])]"):
             return "text"
     except Exception:


### PR DESCRIPTION
## Summary
- ensure checkbox-based dropdowns are classified before numeric inputs when detecting filter types

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d51001975c832393d69a20a05ca00b