### PR TITLE
Improve multiselect filter detection

### DIFF
--- a/libs/excel_params.py
+++ b/libs/excel_params.py
@@ -2376,8 +2376,17 @@ def _detect_filter_type():
             texts = [i.get_attribute("value") or "" for i in dd.find_elements(By.CSS_SELECTOR, ".ant-picker .ant-picker-input input")]
             has_time = any(":" in t for t in texts)
             return "datetime" if has_time else "date"
-        if dd.find_elements(By.CSS_SELECTOR, ".ant-checkbox-wrapper, .ant-dropdown-menu-item, .ant-select-item-option"):
-            return "checkbox-list"
+
+        checkbox_selectors = [
+            "input[type='checkbox']",
+            ".ant-checkbox",
+            ".ant-checkbox-wrapper",
+        ]
+        for _ in range(3):
+            if any(dd.find_elements(By.CSS_SELECTOR, sel) for sel in checkbox_selectors):
+                return "checkbox-list"
+            time.sleep(0.1)
+
         if dd.find_elements(By.CSS_SELECTOR, "input[inputmode='numeric'], input[type='number']"):
             return "numeric"
         if dd.find_elements(By.XPATH, ".//input[not(@type='hidden') and not(@readonly) and not(ancestor::*[contains(@class,'ant-select')])]"):


### PR DESCRIPTION
## Summary
- add dedicated checkbox selectors when detecting Ant filter dropdown type
- wait briefly for checkbox items to render before falling back to numeric classification

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d522f631d48323873089bb82f9aebd