### PR TITLE
Ensure Check Report Filters clears filters between columns

### DIFF
--- a/libs/excel_params.py
+++ b/libs/excel_params.py
@@ -1589,6 +1589,8 @@ def check_report_filters(
             _smoke_filter_ui(anchor, ftype, row_index=row_index)
         except Exception as e:
             _log(f"[COLUMN] {anchor} — filter smoke failed: {type(e).__name__}: {e}", level="WARN")
+        finally:
+            _clear_all_filters_if_present()
 
         processed += 1
         _log(f"[COLUMN] {anchor} — done")


### PR DESCRIPTION
## Summary
- ensure Check Report Filters always resets filters between columns by triggering the global clear action

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d532d5ed988323a2502fec4c87c2f1